### PR TITLE
Change ImageStatus enum

### DIFF
--- a/InterFAX.Api/ListSortOrder.cs
+++ b/InterFAX.Api/ListSortOrder.cs
@@ -5,6 +5,7 @@
     public enum ImageStatus
     {
         READ,
-        UNREAD
+        UNREAD,
+        DONT_EXIST
     }
 }


### PR DESCRIPTION
Add to the enum the value of DONT_EXIST which is returned if the fax
image was deleted from InterFAX