### PR TITLE
Fix for "204 - No Content" Response

### DIFF
--- a/InterFAX.Api/Documents.cs
+++ b/InterFAX.Api/Documents.cs
@@ -161,6 +161,7 @@ namespace InterFAX.Api
                 Array.Copy(buffer, data, len);
                 var response = UploadDocumentChunk(sessionId, fileStream.Position - len, data).Result;
                 if (response.StatusCode == HttpStatusCode.Accepted) continue;
+                if (response.StatusCode == HttpStatusCode.NoContent) continue;
                 if (response.StatusCode == HttpStatusCode.OK) break;
 
                 throw new ApiException(response.StatusCode, new Error

--- a/InterFAX.Api/Documents.cs
+++ b/InterFAX.Api/Documents.cs
@@ -161,7 +161,7 @@ namespace InterFAX.Api
                 Array.Copy(buffer, data, len);
                 var response = UploadDocumentChunk(sessionId, fileStream.Position - len, data).Result;
                 if (response.StatusCode == HttpStatusCode.Accepted) continue;
-                if (response.StatusCode == HttpStatusCode.NoContent) continue;
+                if (response.StatusCode == HttpStatusCode.NoContent) break;
                 if (response.StatusCode == HttpStatusCode.OK) break;
 
                 throw new ApiException(response.StatusCode, new Error

--- a/InterFAX.Api/Documents.cs
+++ b/InterFAX.Api/Documents.cs
@@ -161,7 +161,7 @@ namespace InterFAX.Api
                 Array.Copy(buffer, data, len);
                 var response = UploadDocumentChunk(sessionId, fileStream.Position - len, data).Result;
                 if (response.StatusCode == HttpStatusCode.Accepted) continue;
-                if (response.StatusCode == HttpStatusCode.NoContent) break;
+                if (response.StatusCode == HttpStatusCode.NoContent) continue;
                 if (response.StatusCode == HttpStatusCode.OK) break;
 
                 throw new ApiException(response.StatusCode, new Error


### PR DESCRIPTION
Due to a recent change in the RESTful Endpoint, certain methods return a 204 response, instead of 200.  This resolves the code from throwing a false exception upon attempting to submit large files.