### PR TITLE
Override JsonConvert.DefaultSettings in FaxClient can make legacy app is broken.

### DIFF
--- a/InterFAX.Api/Documents.cs
+++ b/InterFAX.Api/Documents.cs
@@ -1,6 +1,8 @@
+using InterFAX.Api.Dtos;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -8,9 +10,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading.Tasks;
-using InterFAX.Api.Dtos;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace InterFAX.Api
 {
@@ -49,8 +48,8 @@ namespace InterFAX.Api
                     }
                     var settings = new JsonSerializerSettings();
                     settings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
-                    
-                    var mappings = JsonConvert.DeserializeObject<List<MediaTypeMapping>>(File.ReadAllText(typesFile));
+
+                    var mappings = JsonConvert.DeserializeObject<List<MediaTypeMapping>>(File.ReadAllText(typesFile), settings);
                     _supportedMediaTypes = mappings.ToDictionary(
                                 mapping => mapping.FileType,
                                 mapping => mapping.MediaType);
@@ -107,7 +106,7 @@ namespace InterFAX.Api
         public IFaxDocument BuildFaxDocument(string fileName, FileStream fileStream)
         {
             var extension = Path.GetExtension(fileName) ?? "*";
-            extension = extension.TrimStart('.').ToLower();;
+            extension = extension.TrimStart('.').ToLower(); ;
 
             var mediaType = SupportedMediaTypes.Keys.Contains(extension)
                 ? SupportedMediaTypes[extension]
@@ -185,7 +184,7 @@ namespace InterFAX.Api
 
                 throw new ApiException(response.StatusCode, new Error
                 {
-                    Code = (int) response.StatusCode,
+                    Code = (int)response.StatusCode,
                     Message = response.ReasonPhrase,
                     MoreInfo = response.Content.ReadAsStringAsync().Result
                 });
@@ -208,7 +207,7 @@ namespace InterFAX.Api
 
             UploadFileStreamToSession(sessionId, fileStream);
 
-            return GetUploadSession(sessionId).Result;            
+            return GetUploadSession(sessionId).Result;
         }
 
         /// <summary>
@@ -226,7 +225,7 @@ namespace InterFAX.Api
             var sessionId = CreateUploadSession(new UploadSessionOptions
             {
                 Name = fileInfo.Name,
-                Size = (int) fileInfo.Length
+                Size = (int)fileInfo.Length
             }).Result;
 
             using (var fileStream = File.OpenRead(filePath))

--- a/InterFAX.Api/FaxClient.cs
+++ b/InterFAX.Api/FaxClient.cs
@@ -1,17 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Configuration;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
-using InterFAX.Api.Dtos;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace InterFAX.Api
 {
@@ -42,7 +32,7 @@ namespace InterFAX.Api
         /// <param name="password"></param>
         /// <param name="messageHandler"></param>
         /// <param name="ApiRoot">(Optional) Alternative API Root</param>
-        public FaxClient(string username, string password, HttpMessageHandler messageHandler = null, ApiRoot apiRoot=ApiRoot.InterFAX_Default)
+        public FaxClient(string username, string password, HttpMessageHandler messageHandler = null, ApiRoot apiRoot = ApiRoot.InterFAX_Default)
         {
             Initialise(username, password, apiRoot: apiRoot, messageHandler: messageHandler);
         }
@@ -65,11 +55,11 @@ namespace InterFAX.Api
         /// <param name="httpClient">Custom httpClient instance</param>
         /// <param name="ApiRoot">(Optional) Alternative API Root</param>
         public FaxClient(string username, string password, HttpClient httpClient, ApiRoot apiRoot = ApiRoot.InterFAX_Default)
-		{
-			Initialise(username, password, apiRoot:apiRoot, messageHandler:null, httpClient:httpClient);
-		}
+        {
+            Initialise(username, password, apiRoot: apiRoot, messageHandler: null, httpClient: httpClient);
+        }
 
-		private void Initialise(string username, string password, ApiRoot apiRoot, HttpMessageHandler messageHandler = null, HttpClient httpClient = null)
+        private void Initialise(string username, string password, ApiRoot apiRoot, HttpMessageHandler messageHandler = null, HttpClient httpClient = null)
         {
             if (string.IsNullOrEmpty(username))
                 throw new ArgumentException($"{UsernameConfigKey} has not been set.");
@@ -83,7 +73,7 @@ namespace InterFAX.Api
             Documents = new Documents(this);
 
             HttpClient = messageHandler == null ? new HttpClient() : new HttpClient(messageHandler);
-			HttpClient = httpClient != null ? httpClient : HttpClient;
+            HttpClient = httpClient != null ? httpClient : HttpClient;
 
             var root = "";
             switch (apiRoot)
@@ -105,15 +95,15 @@ namespace InterFAX.Api
             HttpClient.BaseAddress = new Uri(root);
             HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             HttpClient.DefaultRequestHeaders.Add("Authorization",
-                new List<string> {$"Basic {Utils.Base64Encode($"{username}:{password}")}"});
+                new List<string> { $"Basic {Utils.Base64Encode($"{username}:{password}")}" });
 
-            JsonConvert.DefaultSettings = () =>
-            {
-                var settings = new JsonSerializerSettings();
-		//Required StringEnumConverter moved to Documents.cs as Custom settings, instead of overriding defaults.
-                //settings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
-                return settings;
-            };
+            //          JsonConvert.DefaultSettings = () =>
+            //          {
+            //              var settings = new JsonSerializerSettings();
+            ////Required StringEnumConverter moved to Documents.cs as Custom settings, instead of overriding defaults.
+            //              //settings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
+            //              return settings;
+            //          };
         }
     }
 }


### PR DESCRIPTION
Issue: Override JsonConvert.DefaultSettings can cause other app is broken. Like some legacy app still uses DateFormatHandling = DateFormatHandling.MicrosoftDateFormat.
I review FaxClient and don't see these code does anything. So, please just remove it.